### PR TITLE
Bugfix for anndata that have gene symbols in adata.var.index, but not…

### DIFF
--- a/finetuning/scvi/scvi_mlp.py
+++ b/finetuning/scvi/scvi_mlp.py
@@ -87,6 +87,8 @@ class ScviCellTypeAnnotationDataset(Dataset):
 
 
 def update_genes(fine_tune_adata, var_file, sctab_format):
+    if not 'feature_name' in fine_tune_adata.var.columns:
+        fine_tune_adata.var["feature_name"] = fine_tune_adata.var.index
     fine_tune_adata.var_names = fine_tune_adata.var.feature_name
     new_adata = prep_for_evaluation(fine_tune_adata, sctab_format, var_file)
     return new_adata


### PR DESCRIPTION
… a separate column named feature_names